### PR TITLE
Added .gitignore to exclude specific system files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+**/.Trashes
+**/.DS_Store
+**/desktop.ini
+.vscode


### PR DESCRIPTION
I noticed there was a `.DS_Store` file in the `tools` directory, so decided to add a `.gitignore` file with a few entries for common system files (both Windows and MacOS).