### PR TITLE
Minor Error Handling Modifications

### DIFF
--- a/examples/pqc-demo/consumer.sh
+++ b/examples/pqc-demo/consumer.sh
@@ -55,7 +55,7 @@ do
             if [ -z "$2" ]; then
                 show_usage "Missing --keystore argument"
             fi
-            KEYSTORE_PATH=$2
+            KEYSTORE_PATH=${2%/}
             shift
             ;;
         *)

--- a/examples/pqc-demo/publisher.sh
+++ b/examples/pqc-demo/publisher.sh
@@ -55,7 +55,7 @@ do
             if [ -z "$2" ]; then
                 show_usage "Missing --keystore argument"
             fi
-            KEYSTORE_PATH=$2
+            KEYSTORE_PATH=${2%/}
             shift
             ;;
         *)


### PR DESCRIPTION
Modified scripts are lacking the ability to gracefully handle a trailing slash in supplied path for the keystore parameter. This is anonying because linux adds a trailing slash when using auto complete on CLI which a user needs to manually remove. 

The modification removes any trailing slash (if existing) so the rest of the script does not need any additional modification.